### PR TITLE
Retry against Porkbun API errors

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -219,9 +219,13 @@ func updateDns(cfg domConfig, ipAddr ip) (bool, error) {
 	}
 
 	// Send API request
+	// TODO: need to wrap this around with exponential backoff, no external deps.
 	resp, err := client.Post(fmt.Sprintf("https://api.porkbun.com/api/json/v3/dns/retrieveByNameType/%s/%s/%s", cfg.Domain, recordType, cfg.Subdomain), "application/json", bytes.NewBuffer(reqBody))
 	if err != nil {
 		return false, fmt.Errorf("error sending API request: %s", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("received status code: %v", resp.StatusCode)
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
I'd been getting some weird responses from the Porkbun API as described in #12 which would sometimes lead to Oink exiting with failure and my domains not getting updated. This adds a naive backoff for those POST requests and also makes sure that we don't try to parse a 503's response as JSON (which would give a confusing error as in https://github.com/RLado/Oink/issues/12#issuecomment-2591878970).

I've been running these changes for a few months without issue, and at least from my logs all of the 503s returned by Porkbun's API were eventually successful.
